### PR TITLE
Create authentication.conf

### DIFF
--- a/mqtt/config/conf.d/authentication.conf
+++ b/mqtt/config/conf.d/authentication.conf
@@ -1,0 +1,9 @@
+### Auf false setzen, falls anonyme Verbindungen verboten werden sollen.
+allow_anonymous true
+
+password_file /mosquitto/config/password_file
+
+### Neue Benutzer können danach mit
+### docker exec -it fhem-docker-mqtt-1 mosquitto_passwd  /mosquitto/config/password_file <BENUTZERNAME>
+### hinzugefügt werden
+### weitere Infos: https://mosquitto.org/man/mosquitto_passwd-1.html


### PR DESCRIPTION
Vorbereitung für Verbindungen mit Benutzername/Kennwort. Anonyme Verbindungen sind weiterhin möglich solange allow_anonymous auf true steht.