### PR TITLE
Mosquitto.conf

### DIFF
--- a/mqtt/config/mosquitto.conf
+++ b/mqtt/config/mosquitto.conf
@@ -4,7 +4,7 @@ persistence_location /mosquitto/data/
 user root
 port 1883
 
-log_dest file /mosquitto/log/mosquitto.log
-log_dest stdout
+# Wird für Mosquitto 2.x benötigt
+allow_anonymous true
 
 include_dir /mosquitto/config/conf.d


### PR DESCRIPTION
- Logging einstellungen sind doppelt und schon in ./conf.d/logging.conf enthalten
- Mosquitto 2.x benötigt den Eintrag `allow_anonymous true`

